### PR TITLE
Add unicode support to the updated clap dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ clap = { version = "3", default-features = false, features = [
     "derive",
     "unicode",
 ] }
-clap_derive = { version = "3" }
+heck = { version = "*", features = ["unicode"] } # Add unicode support to clap
 uuid = { version = "1.0.0", features = ["v4"] }
 cansi = "2.1.1"
 eframe = { version = "0.16.0", default-features = false, features = [


### PR DESCRIPTION
As mentioned by @MichalGniadek in https://github.com/MichalGniadek/klask/pull/36, `clap` was not correctly processing non-ascii unicode characters as field names after `3.0.0`, which was blocking the update.

This happened the crate that they use for case conversion (`heck`) does not support unicode by default, as they hide it behind a feature. This commit just enables that feature for the version of `heck` that `clap` uses to make unicode characters work after the update.

Example:
```rust
#[derive(Debug, Parser)]
#[clap(name = "App name")]
/// Help is displayed at the top
pub struct Showcase {
    # [clap(long, value_hint = ValueHint::AnyPath)]
    çæß: PathBuf,
    /// Argument help is displayed as tooltips
    required_field: String,
    #[clap(long)]
    optional_field: Option<String>,
    #[clap(long, default_value = "default value")]
    field_with_default: String,
    #[clap(long)]
    flag: bool,
    #[clap(short, parse(from_occurrences))]
    count_occurrences_as_a_nice_counter: i32,
    #[clap(subcommand)]
    subcommand: Subcommand,
}
```

![Screenshot_20220702_112507](https://user-images.githubusercontent.com/4929005/176994988-5b1961dd-c65e-455b-9250-eedd999edc92.png)

